### PR TITLE
Proposal: Add IAM identity Center SSO Support 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,16 @@
         <version>${httpclient.version}</version>
       </dependency>
       <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>sso</artifactId>
+        <version>${aws-java-sdk.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>ssooidc</artifactId>
+        <version>${aws-java-sdk.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>


### PR DESCRIPTION
Adding these two dependencies enables the DefaultCredentialsProvider to use SSO credentials i.e. this plugin can be used by users that need to use IAM Identity Center SSO. See also: 

- https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html 
- https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-temporary.html#credentials-temporary-idc