### PR TITLE
sso dependencies should really be dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,12 +126,10 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sso</artifactId>
-      <version>${aws-java-sdk.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>ssooidc</artifactId>
-      <version>${aws-java-sdk.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,16 @@
       <version>${javax-inject.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sso</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>ssooidc</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -131,16 +141,6 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>${httpclient.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>sso</artifactId>
-        <version>${aws-java-sdk.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>ssooidc</artifactId>
-        <version>${aws-java-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>


### PR DESCRIPTION
Hi Jae, I messed up, probably during my force push to sign the commit in the last PR. The AWS SSO dependencies should of course be in "dependencies" and not "dependencyManagement". 
Not sure how that happened, I definitely had the correct version once. 

Sorry for that, at least it did not break anything.
