### PR TITLE
Allow access using assumed roles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>ssooidc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
We use assumed roles with `credential_process` (backed by aws-vault, but that shouldn't matter).
With this setup it's possible to access codeartifact specifying only the AWS profile,
but trying that with maven and this plugin results in an error message that boils down to:

> To use assumed roles in the 'redacted' profile, the 'sts' service module must be on the class path

I can fix that locally by adding the `sts` dependency to my POM (`build/plugins/plugin/dependencies` for this plugin),
but it seems more reasonable to move the fix upstream :)
