### PR TITLE
- added support for aws profile credentials provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <javax-inject.version>1</javax-inject.version>
     <junit.version>5.11.0</junit.version>
     <mockito.version>3.2.4</mockito.version>
+    <system-stubs.version>2.1.8</system-stubs.version>
     <slf4j.version>1.7.36</slf4j.version>
 
     <!-- plugins -->
@@ -103,6 +104,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>${system-stubs.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/io/dangernoodle/codeartifact/maven/CodeArtifact.java
+++ b/src/main/java/io/dangernoodle/codeartifact/maven/CodeArtifact.java
@@ -2,6 +2,7 @@ package io.dangernoodle.codeartifact.maven;
 
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
@@ -20,6 +21,10 @@ import java.util.regex.Pattern;
  */
 public class CodeArtifact
 {
+    public static final String AWS_PROFILE_PROPERTY_NAME = "dangernoodle.codeartifact.aws.profile";
+
+    public static final String AWS_PROFILE_ENV_VARIABLE_NAME = "DANGERNOODLE_CODEARTIFACT_AWS_PROFILE";
+
     private static final String KEY = "codeartifact.maven.token.duration";
 
     private static final Pattern DOMAIN_AND_DOMAIN_OWNER_PATTERN = Pattern.compile("(.*)-(.*)");
@@ -51,14 +56,26 @@ public class CodeArtifact
 
     private AwsCredentialsProvider createProvider(Credentials credentials)
     {
+        if (credentials.username != null && credentials.password != null) 
+        {
+            return createStaticCredentials(credentials);
+        }
+        if (credentials.awsProfile != null)
+        {
+            return createProfileCredentials(credentials);
+        }
         // null == use of the DefaultProviderChain
-        return (credentials.username != null && credentials.password != null) ?
-                createStaticCredentials(credentials) : null;
+        return null;
     }
 
     private AwsCredentialsProvider createStaticCredentials(Credentials credentials)
     {
         return StaticCredentialsProvider.create(AwsBasicCredentials.create(credentials.username, credentials.password));
+    }
+
+    private AwsCredentialsProvider createProfileCredentials(Credentials credentials)
+    {
+        return ProfileCredentialsProvider.create(credentials.awsProfile);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -112,10 +129,13 @@ public class CodeArtifact
 
         public final String username;
 
+        public final String awsProfile;
+
         private Credentials(String password, Instant timestamp)
         {
             this.username = "codecommit";
             this.password = password;
+            this.awsProfile = null;
             this.expiration = timestamp;
         }
 
@@ -123,6 +143,15 @@ public class CodeArtifact
         {
             this.username = username;
             this.password = password;
+            this.awsProfile = null;
+            this.expiration = null;
+        }
+
+        public Credentials(String awsProfile)
+        {
+            this.username = null;
+            this.password = null;
+            this.awsProfile = awsProfile;
             this.expiration = null;
         }
     }

--- a/src/main/java/io/dangernoodle/codeartifact/maven/resolver/CodeArtifactTransportFactory.java
+++ b/src/main/java/io/dangernoodle/codeartifact/maven/resolver/CodeArtifactTransportFactory.java
@@ -11,7 +11,6 @@ import org.eclipse.aether.transport.http.HttpTransporterFactory;
 import org.eclipse.aether.util.repository.AuthenticationBuilder;
 
 import javax.inject.Named;
-import java.util.Optional;
 
 
 /**
@@ -67,6 +66,15 @@ public class CodeArtifactTransportFactory implements TransporterFactory
         return new HttpTransporterFactory();
     }
 
+    private String getAwsProfile() 
+    {
+        final String profile = System.getProperty(CodeArtifact.AWS_PROFILE_PROPERTY_NAME);
+        if (profile != null) {
+            return profile;
+        }
+        return System.getenv(CodeArtifact.AWS_PROFILE_ENV_VARIABLE_NAME);
+    }
+
     private boolean areKeysSet(AuthenticationContext context)
     {
         return toUsername(context) != null && toPassword(context) != null;
@@ -89,15 +97,16 @@ public class CodeArtifactTransportFactory implements TransporterFactory
 
     private CodeArtifact.Credentials createCredentials(AuthenticationContext context)
     {
-        return Optional.ofNullable(context)
-                       .filter(this::areKeysSet)
-                       .map(this::toCredentials)
-                       .orElse(CodeArtifact.Credentials.EMPTY);
-    }
-
-    private CodeArtifact.Credentials toCredentials(AuthenticationContext context)
-    {
-        return new CodeArtifact.Credentials(toUsername(context), toPassword(context));
+        if (context != null && areKeysSet(context)) 
+        {
+            return new CodeArtifact.Credentials(toUsername(context), toPassword(context));
+        }
+        final String awsProfile = getAwsProfile();
+        if (awsProfile != null)
+        {
+            return new CodeArtifact.Credentials(awsProfile);
+        }
+        return CodeArtifact.Credentials.EMPTY;
     }
 
     private String toPassword(AuthenticationContext context)

--- a/src/test/java/io/dangernoodle/codeartifact/maven/CodeArtifactTest.java
+++ b/src/test/java/io/dangernoodle/codeartifact/maven/CodeArtifactTest.java
@@ -17,6 +17,7 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient;
 import software.amazon.awssdk.services.codeartifact.CodeartifactClientBuilder;
@@ -33,6 +34,8 @@ public class CodeArtifactTest
     public static final String PASSWORD = "AWS_SECRET_ACCESS_KEY";
 
     public static final String USERNAME = "AWS_ACCESS_KEY_ID";
+
+    public static final String AWS_PROFILE = "code-artifact";
 
     private static final String HOST = "domain-account.d.codeartifact.region.amazonaws.com";
 
@@ -155,6 +158,15 @@ public class CodeArtifactTest
         thenStaticProviderUsed();
     }
 
+    @Test
+    public void testProfileCredentials()
+    {
+        givenAProfile();
+        whenCreateClient();
+        thenRegionIsConfigured();
+        thenProfileProviderUsed();
+    }
+
     private void givenACodeArtifactUrl()
     {
         url = HOST + "/maven/repository";
@@ -210,6 +222,11 @@ public class CodeArtifactTest
         mockCredentials = new CodeArtifact.Credentials(USERNAME, PASSWORD);
     }
 
+    private void givenAProfile()
+    {
+        mockCredentials = new CodeArtifact.Credentials(AWS_PROFILE);
+    }
+
     private void thenCachedCredentialsUsed()
     {
         verifyNoMoreInteractions(mockClient);
@@ -239,6 +256,11 @@ public class CodeArtifactTest
 
         assertEquals(USERNAME, providerCaptor.getValue().resolveCredentials().accessKeyId());
         assertEquals(PASSWORD, providerCaptor.getValue().resolveCredentials().secretAccessKey());
+    }
+
+    private void thenProfileProviderUsed()
+    {
+        verify(mockClientBuilder).credentialsProvider(any(ProfileCredentialsProvider.class));
     }
 
     private void thenTokenRequestIsCorrect()

--- a/src/test/java/io/dangernoodle/codeartifact/maven/resolver/CodeArtifactTransportFactoryTest.java
+++ b/src/test/java/io/dangernoodle/codeartifact/maven/resolver/CodeArtifactTransportFactoryTest.java
@@ -1,5 +1,6 @@
 package io.dangernoodle.codeartifact.maven.resolver;
 
+import static io.dangernoodle.codeartifact.maven.CodeArtifactTest.AWS_PROFILE;
 import static io.dangernoodle.codeartifact.maven.CodeArtifactTest.PASSWORD;
 import static io.dangernoodle.codeartifact.maven.CodeArtifactTest.USERNAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,6 +13,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.dangernoodle.codeartifact.maven.CodeArtifact;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -27,7 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, SystemStubsExtension.class})
 public class CodeArtifactTransportFactoryTest
 {
     @Captor
@@ -36,6 +41,9 @@ public class CodeArtifactTransportFactoryTest
     private CodeArtifactTransportFactory factory;
 
     private Authentication mockAuthentication;
+
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
 
     @Mock
     private CodeArtifact mockCodeArtifact;
@@ -48,8 +56,6 @@ public class CodeArtifactTransportFactoryTest
 
     @Mock
     private RepositorySystemSession mockSession;
-
-    private float priority;
 
     @BeforeEach
     public void beforeEach()
@@ -68,6 +74,8 @@ public class CodeArtifactTransportFactoryTest
                 return mockFactory;
             }
         };
+
+        System.clearProperty(CodeArtifact.AWS_PROFILE_PROPERTY_NAME);
     }
 
     @Test
@@ -124,6 +132,38 @@ public class CodeArtifactTransportFactoryTest
         thenPassedCredentialsAreStatic();
     }
 
+    @Test
+    public void testProfileCredentialsFromEnvVariable() throws Exception
+    {
+        givenAUrlThatIsCodeArtifact();
+        givenAProfileEnvVariable();
+        whenCreateTransportFactory();
+        thenCredentialsAreGenerated();
+        thenPassedCredentialsContainProfile();
+    }
+
+    @Test
+    public void testProfileCredentialsFromProperty() throws Exception
+    {
+        givenAUrlThatIsCodeArtifact();
+        givenAProfileProperty();
+        whenCreateTransportFactory();
+        thenCredentialsAreGenerated();
+        thenPassedCredentialsContainProfile();
+    }
+
+    @Test
+    public void testStaticCredentialsTakePresentsOverProfileCredentials() throws Exception
+    {
+        givenAUrlThatIsCodeArtifact();
+        givenStaticCredentials();
+        givenAProfileProperty();
+        whenCreateTransportFactory();
+        thenCredentialsAreGenerated();
+        thenPassedCredentialsAreStatic();
+        thenPassedCredentialsDoNotContainProfile();
+    }
+
     private RemoteRepository createMockRepository()
     {
         // url doesn't matter b/c of mocking
@@ -165,6 +205,16 @@ public class CodeArtifactTransportFactoryTest
                                                         .build();
     }
 
+    private void givenAProfileEnvVariable()
+    {
+        environmentVariables.set(CodeArtifact.AWS_PROFILE_ENV_VARIABLE_NAME, AWS_PROFILE);
+    }
+
+    private void givenAProfileProperty()
+    {
+        System.setProperty(CodeArtifact.AWS_PROFILE_PROPERTY_NAME, AWS_PROFILE);
+    }
+
     private void thenCredentialsAreGenerated()
     {
         verify(mockCodeArtifact).createCredentials(anyString(), credsCaptor.capture());
@@ -185,6 +235,16 @@ public class CodeArtifactTransportFactoryTest
     {
         assertEquals(USERNAME, credsCaptor.getValue().username);
         assertEquals(PASSWORD, credsCaptor.getValue().password);
+    }
+
+    private void thenPassedCredentialsContainProfile()
+    {
+        assertEquals(AWS_PROFILE, credsCaptor.getValue().awsProfile);
+    }
+
+    private void thenPassedCredentialsDoNotContainProfile()
+    {
+        assertNull(credsCaptor.getValue().awsProfile);
     }
 
     private void thenPriorityIsGreater()


### PR DESCRIPTION
This change allow to use `ProfileCredentialsProvider`. Profile can be passed via env variable `DANGERNOODLE_CODEARTIFACT_AWS_PROFILE` or CLI property `dangernoodle.codeartifact.aws.profile`.  CLI property has higher priority than env variable.

Credentials resolution chain:
- `StaticCredentialsProvider`
- `ProfileCredentialsProvider`
- `DefaultCredentialsProvider`

This change allows to use AWS profile for credentials even when AWS access keys are already defined in the environment variables.
Helps to have more clear boundaries for credentials that are used in CI pipelines. 